### PR TITLE
Remove static markup from NodeStreamRenderer

### DIFF
--- a/src/server/ReactDOMNodeStreamRenderer.js
+++ b/src/server/ReactDOMNodeStreamRenderer.js
@@ -99,7 +99,7 @@ function originalRenderToNodeStream(element, cache, streamingStart, memLife=0) {
   return new ReactMarkupReadableStream(element, false, cache, streamingStart, memLife);
 }
 
-export function renderToNodeStream(element, cache, res, htmlStart, htmlEnd) {
+export function renderToNodeStream(element, cache, res, htmlStart, htmlEnd, memLife) {
 
   const streamingStart = {
     sliceStartCount: htmlStart.length, 
@@ -109,7 +109,7 @@ export function renderToNodeStream(element, cache, res, htmlStart, htmlEnd) {
     cacheStream.pipe(res);
     cacheStream.write(htmlStart);
 
-    const stream = originalRenderToNodeStream(element, cache, streamingStart);
+    const stream = originalRenderToNodeStream(element, cache, streamingStart, memLife);
     stream.pipe(cacheStream, { end: false });
     stream.on("end", () => {
       cacheStream.end(htmlEnd);
@@ -126,7 +126,7 @@ function originalRenderToStaticNodeStream(element, cache, streamingStart, memLif
   return new ReactMarkupReadableStream(element, true, cache, streamingStart, memLife);
 }
 
-export function renderToStaticNodeStream(element, cache, res, htmlStart, htmlEnd) {
+export function renderToStaticNodeStream(element, cache, res, htmlStart, htmlEnd, memLife) {
 
   const streamingStart = {
     sliceStartCount: htmlStart.length, 
@@ -136,7 +136,7 @@ export function renderToStaticNodeStream(element, cache, res, htmlStart, htmlEnd
     cacheStream.pipe(res);
     cacheStream.write(htmlStart);
 
-    const stream = originalRenderToStaticNodeStream(element, cache, streamingStart);
+    const stream = originalRenderToStaticNodeStream(element, cache, streamingStart, memLife);
     stream.pipe(cacheStream, { end: false });
     stream.on("end", () => {
       cacheStream.end(htmlEnd);

--- a/src/server/ReactDOMNodeStreamRenderer.js
+++ b/src/server/ReactDOMNodeStreamRenderer.js
@@ -99,12 +99,7 @@ function originalRenderToNodeStream(element, cache, streamingStart, memLife=0) {
   return new ReactMarkupReadableStream(element, false, cache, streamingStart, memLife);
 }
 
-export function renderToNodeStream(element, cache, res) {
-
-  const htmlStart =
-  '<html><head><title>Page</title></head><body><div id="react-root">';
-
-  const htmlEnd = '</div></body></html>';
+export function renderToNodeStream(element, cache, res, htmlStart, htmlEnd) {
 
   const streamingStart = {
     sliceStartCount: htmlStart.length, 
@@ -131,11 +126,7 @@ function originalRenderToStaticNodeStream(element, cache, streamingStart, memLif
   return new ReactMarkupReadableStream(element, true, cache, streamingStart, memLife);
 }
 
-export function renderToStaticNodeStream(element, cache, res) {
-  const htmlStart =
-  '<html><head><title>Page</title></head><body><div id="react-root">';
-
-  const htmlEnd = '</div></body></html>';
+export function renderToStaticNodeStream(element, cache, res, htmlStart, htmlEnd) {
 
   const streamingStart = {
     sliceStartCount: htmlStart.length, 


### PR DESCRIPTION
The API docs from *NodeStreamRenderer* did not match the actual behaviour. 
htmlStart & htmlEnd should be variables that can be passed to the function, currently they are static defined in the function.