### PR TITLE
Use express-async-handler in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Instantiate a cache and pass it to any rendering method (`renderToString`, `rend
 
 **Note: All of these methods are asynchronous, and return a promise. To use them, `await` the response before rendering**
 ```javascript
+const asyncHandler = require('express-async-handler');
 const ReactCC = require("react-component-caching");
 const cache = new ReactCC.ComponentCache();
 
-app.get('/example', async (req,res) => {
+app.get('/example', asyncHandler(async (req,res) => {
     const renderString = await ReactCC.renderToString(<App />, cache);
     res.send(renderString);
-});
+}));
 
 // ...
 ```


### PR DESCRIPTION
Express does not support async middlware. This PR uses `express-async-handler` to wrap the the async middleware in the example in the README to avoid confusion.

If you use unwrapped async middleware in express and an error occurs in the middleware, the request will hang and an `UnhandledPromiseRejectionWarning` will fire.

```js
app.get('/async-error', async (req, res) => {
  throw new Error(`I'm going to wreak havok`)
})
```

However, if you wrap the async middleware with `express-async-handler`, errors are handled as expected.

```js
const asyncHandler = require('express-async-handler')

app.get('/wrapped-async-error', asyncHandler(async (req, res) => {
	throw new Error(`I'll be handled just like an error in sync context`)
}))
```

Note that `koa` supports async middleware natively.